### PR TITLE
Fix TypeScript any usage in caching and analytics utilities

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -3,14 +3,14 @@ export class BaseError extends Error {
     message: string,
     public code: string,
     public statusCode: number = 500,
-    public details?: any,
+    public details?: unknown,
   ) {
     super(message);
     this.name = this.constructor.name;
     Error.captureStackTrace(this, this.constructor);
   }
 
-  toJSON(): Record<string, any> {
+  toJSON(): Record<string, unknown> {
     return {
       name: this.name,
       message: this.message,
@@ -26,7 +26,7 @@ export class ProviderError extends BaseError {
     public provider: string,
     message: string,
     code: string = 'PROVIDER_ERROR',
-    details?: any,
+    details?: unknown,
   ) {
     super(`[${provider}] ${message}`, code, 500, details);
   }
@@ -43,29 +43,24 @@ export class RateLimitError extends BaseError {
     provider: string,
     public retryAfter?: number,
   ) {
-    super(
-      `[${provider}] Rate limit exceeded`,
-      'RATE_LIMIT_ERROR',
-      429,
-      { retryAfter },
-    );
+    super(`[${provider}] Rate limit exceeded`, 'RATE_LIMIT_ERROR', 429, { retryAfter });
   }
 }
 
 export class ValidationError extends BaseError {
-  constructor(message: string, details?: any) {
+  constructor(message: string, details?: unknown) {
     super(message, 'VALIDATION_ERROR', 400, details);
   }
 }
 
 export class CacheError extends BaseError {
-  constructor(message: string, details?: any) {
+  constructor(message: string, details?: unknown) {
     super(message, 'CACHE_ERROR', 500, details);
   }
 }
 
 export class ConfigurationError extends BaseError {
-  constructor(message: string, details?: any) {
+  constructor(message: string, details?: unknown) {
     super(message, 'CONFIG_ERROR', 500, details);
   }
 }
@@ -80,12 +75,12 @@ export function isRetryableError(error: Error): boolean {
   if (error instanceof RateLimitError) {
     return true;
   }
-  
+
   if (error instanceof ProviderError) {
     const retryableCodes = ['TIMEOUT', 'NETWORK_ERROR', 'SERVER_ERROR'];
     return retryableCodes.includes(error.code);
   }
-  
+
   return false;
 }
 
@@ -93,20 +88,10 @@ export function handleError(error: unknown): BaseError {
   if (error instanceof BaseError) {
     return error;
   }
-  
+
   if (error instanceof Error) {
-    return new BaseError(
-      error.message,
-      'UNKNOWN_ERROR',
-      500,
-      { originalError: error.name },
-    );
+    return new BaseError(error.message, 'UNKNOWN_ERROR', 500, { originalError: error.name });
   }
-  
-  return new BaseError(
-    'An unknown error occurred',
-    'UNKNOWN_ERROR',
-    500,
-    { error: String(error) },
-  );
+
+  return new BaseError('An unknown error occurred', 'UNKNOWN_ERROR', 500, { error: String(error) });
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -9,6 +9,12 @@ export interface DateRange {
   end: Date;
 }
 
+export interface CostBreakdownMetadata {
+  region?: string;
+  tags?: Record<string, string>;
+  [key: string]: unknown;
+}
+
 export interface CostBreakdown {
   service: string;
   amount: number;
@@ -16,6 +22,8 @@ export interface CostBreakdown {
     quantity: number;
     unit: string;
   };
+  date?: Date;
+  metadata?: CostBreakdownMetadata;
 }
 
 export interface UnifiedCostData {
@@ -52,13 +60,13 @@ export interface ProviderClient {
   getProviderName(): Provider;
 }
 
-export interface ToolResponse<T = any> {
+export interface ToolResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: {
     code: string;
     message: string;
-    details?: any;
+    details?: unknown;
   };
 }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,7 +1,8 @@
 import { BaseError } from './errors';
+import type { ProviderClient } from './types';
 
 export async function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export interface RetryOptions {
@@ -12,10 +13,7 @@ export interface RetryOptions {
   shouldRetry?: (error: Error) => boolean;
 }
 
-export async function retry<T>(
-  fn: () => Promise<T>,
-  options: RetryOptions = {},
-): Promise<T> {
+export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   const {
     maxAttempts = 3,
     initialDelay = 1000,
@@ -25,26 +23,23 @@ export async function retry<T>(
   } = options;
 
   let lastError: Error | undefined;
-  
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       return await fn();
     } catch (error) {
       lastError = error as Error;
-      
+
       if (attempt === maxAttempts || !shouldRetry(lastError)) {
         throw lastError;
       }
-      
-      const delay = Math.min(
-        initialDelay * Math.pow(factor, attempt - 1),
-        maxDelay,
-      );
-      
+
+      const delay = Math.min(initialDelay * Math.pow(factor, attempt - 1), maxDelay);
+
       await sleep(delay);
     }
   }
-  
+
   throw lastError || new Error('Retry failed');
 }
 
@@ -60,116 +55,149 @@ export function parseDate(dateStr: string): Date {
   return date;
 }
 
-export function groupBy<T>(
-  items: T[],
-  keyFn: (item: T) => string,
-): Record<string, T[]> {
-  return items.reduce((groups, item) => {
-    const key = keyFn(item);
-    if (!groups[key]) {
-      groups[key] = [];
-    }
-    groups[key].push(item);
-    return groups;
-  }, {} as Record<string, T[]>);
+export function groupBy<T>(items: T[], keyFn: (item: T) => string): Record<string, T[]> {
+  return items.reduce(
+    (groups, item) => {
+      const key = keyFn(item);
+      if (!groups[key]) {
+        groups[key] = [];
+      }
+      groups[key].push(item);
+      return groups;
+    },
+    {} as Record<string, T[]>,
+  );
 }
 
-export function sumBy<T>(
-  items: T[],
-  valueFn: (item: T) => number,
-): number {
+export function sumBy<T>(items: T[], valueFn: (item: T) => number): number {
   return items.reduce((sum, item) => sum + valueFn(item), 0);
 }
 
-export function sanitizeForLog(obj: any): any {
-  if (!obj || typeof obj !== 'object') {
+const SENSITIVE_KEYS = [
+  'password',
+  'secret',
+  'token',
+  'key',
+  'authorization',
+  'api_key',
+  'apikey',
+  'access_token',
+  'refresh_token',
+  'private_key',
+  'client_secret',
+];
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export function sanitizeForLog<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
     return obj;
   }
 
-  const sensitiveKeys = [
-    'password',
-    'secret',
-    'token',
-    'key',
-    'authorization',
-    'api_key',
-    'apikey',
-    'access_token',
-    'refresh_token',
-    'private_key',
-    'client_secret',
-  ];
+  if (obj instanceof Date) {
+    return obj.toISOString() as unknown as T;
+  }
 
-  const sanitized = Array.isArray(obj) ? [...obj] : { ...obj };
+  if (Array.isArray(obj)) {
+    return obj.map((item) => sanitizeForLog(item)) as unknown as T;
+  }
 
-  for (const key in sanitized) {
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
     const lowerKey = key.toLowerCase();
-    
-    if (sensitiveKeys.some(sensitive => lowerKey.includes(sensitive))) {
+
+    if (SENSITIVE_KEYS.some((sensitive) => lowerKey.includes(sensitive))) {
       sanitized[key] = '[REDACTED]';
-    } else if (typeof sanitized[key] === 'object' && sanitized[key] !== null) {
-      sanitized[key] = sanitizeForLog(sanitized[key]);
+    } else {
+      sanitized[key] = sanitizeForLog(value);
     }
   }
 
-  return sanitized;
+  return sanitized as unknown as T;
 }
 
 export class Logger {
-  private level: string;
+  private level: LogLevel;
 
   constructor(level: string = 'info') {
-    this.level = level;
+    const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+    this.level = levels.includes(level as LogLevel) ? (level as LogLevel) : 'info';
   }
 
-  private shouldLog(msgLevel: string): boolean {
-    const levels = ['debug', 'info', 'warn', 'error'];
+  private shouldLog(msgLevel: LogLevel): boolean {
+    const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
     const currentLevelIndex = levels.indexOf(this.level);
     const msgLevelIndex = levels.indexOf(msgLevel);
     return msgLevelIndex >= currentLevelIndex;
   }
 
-  private log(level: string, message: string, data?: any): void {
+  private log(level: LogLevel, message: string, data?: unknown): void {
     if (!this.shouldLog(level)) return;
 
     const timestamp = new Date().toISOString();
-    const sanitizedData = data ? sanitizeForLog(data) : undefined;
-    
-    const logEntry = {
+    const sanitizedData = data !== undefined ? sanitizeForLog(data) : undefined;
+
+    const logEntry: Record<string, unknown> = {
       timestamp,
       level,
       message,
-      ...(sanitizedData && { data: sanitizedData }),
     };
+
+    if (sanitizedData !== undefined) {
+      logEntry.data = sanitizedData;
+    }
 
     console.log(JSON.stringify(logEntry));
   }
 
-  debug(message: string, data?: any): void {
+  debug(message: string, data?: unknown): void {
     this.log('debug', message, data);
   }
 
-  info(message: string, data?: any): void {
+  info(message: string, data?: unknown): void {
     this.log('info', message, data);
   }
 
-  warn(message: string, data?: any): void {
+  warn(message: string, data?: unknown): void {
     this.log('warn', message, data);
   }
 
-  error(message: string, error?: Error | BaseError | any): void {
-    const errorData = error instanceof Error ? {
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-      ...(error instanceof BaseError && {
-        code: error.code,
-        details: error.details,
-      }),
-    } : error;
-    
+  error(message: string, error?: unknown): void {
+    let errorData: unknown = error;
+
+    if (error instanceof Error) {
+      errorData = {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+        ...(error instanceof BaseError && {
+          code: error.code,
+          details: error.details,
+        }),
+      };
+    }
+
     this.log('error', message, errorData);
   }
+}
+
+export function resolveProviderName(provider: ProviderClient): string {
+  const providerLike = provider as Partial<ProviderClient> & { name?: string };
+
+  if (typeof providerLike.getProviderName === 'function') {
+    try {
+      const name = providerLike.getProviderName();
+      if (name) {
+        return name;
+      }
+    } catch (error) {
+      // Fall back to other strategies if calling getProviderName fails
+      logger.debug('Failed to read provider name via getProviderName', { error });
+    }
+  }
+
+  return providerLike.name ?? 'unknown';
 }
 
 export const logger = new Logger(process.env.LOG_LEVEL || 'info');


### PR DESCRIPTION
## Summary
- add structured cache key typing and key enumeration support to the cache manager
- tighten common error, logging, and type definitions to remove `any` usage
- update cost analysis tools to rely on typed metadata and provider name resolution instead of casts

## Testing
- npm run lint
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_69060fefb9908326bc31a1aaeea264bb