### PR TITLE
Add protocol-level MCP handler tests

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,8 +1,10 @@
 import { CostManagementMCPServer } from '../src/server';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { getConfig } from '../src/common/config';
 import { initializeCache } from '../src/common/cache';
-import { toolDefinitions } from '../src/tools/registry';
+import { toolDefinitions, type ToolDefinition } from '../src/tools/registry';
+import * as errors from '../src/common/errors';
 
 // Mock dependencies
 jest.mock('@modelcontextprotocol/sdk/server/index.js');
@@ -39,7 +41,10 @@ describe('CostManagementMCPServer', () => {
 
     // Mock Server constructor
     (Server as jest.Mock).mockImplementation(() => ({
-      setRequestHandler: jest.fn(),
+      handlers: [] as Array<{ schema: unknown; handler: (...args: unknown[]) => unknown }>,
+      setRequestHandler: jest.fn(function (this: any, schema, handler) {
+        this.handlers.push({ schema, handler });
+      }),
       connect: jest.fn().mockResolvedValue(undefined),
     }));
   });
@@ -109,6 +114,109 @@ describe('CostManagementMCPServer', () => {
       expect(costGetTool.inputSchema.properties).toHaveProperty('startDate');
       expect(costGetTool.inputSchema.properties).toHaveProperty('endDate');
       expect(costGetTool.inputSchema.required).toEqual(['startDate', 'endDate']);
+    });
+  });
+
+  describe('MCP protocol handlers', () => {
+    const getRegisteredHandler = (mockServer: any, schema: unknown) => {
+      const match = mockServer.setRequestHandler.mock.calls.find(
+        ([registeredSchema]: [unknown]) => registeredSchema === schema,
+      );
+
+      expect(match).toBeDefined();
+      return match![1] as (...args: any[]) => Promise<any>;
+    };
+
+    it('should respond with available tools via ListTools handler', async () => {
+      mockConfig.getProviderConfig.mockReturnValue({
+        enabled: true,
+        credentials: { apiKey: 'test-key' },
+      });
+
+      server = new CostManagementMCPServer();
+
+      const mockServer = (server as any).server;
+      const listHandler = getRegisteredHandler(mockServer, ListToolsRequestSchema);
+      const response = await listHandler({ params: {} });
+
+      expect(response.tools).toEqual(toolDefinitions.map((definition) => definition.metadata));
+    });
+
+    it('should execute tool handlers when receiving CallTool requests', async () => {
+      mockConfig.getProviderConfig.mockReturnValue({
+        enabled: true,
+        credentials: { apiKey: 'test-key' },
+      });
+
+      server = new CostManagementMCPServer();
+
+      const mockServer = (server as any).server;
+      const callHandler = getRegisteredHandler(mockServer, CallToolRequestSchema);
+      const toolRegistry = (server as any).toolRegistry as Map<string, ToolDefinition>;
+      const definition = toolRegistry.get('provider_list');
+      expect(definition).toBeDefined();
+
+      const mockResponse = { content: [{ type: 'text', text: 'ok' }] };
+      const originalHandler = definition!.handler;
+      const mockHandler = jest.fn().mockResolvedValue(mockResponse);
+      definition!.handler = mockHandler;
+
+      const args = { includeInactive: true };
+      const result = await callHandler({
+        params: {
+          name: 'provider_list',
+          arguments: args,
+        },
+      });
+
+      expect(mockHandler).toHaveBeenCalledWith(args, (server as any).providers);
+      expect(result).toBe(mockResponse);
+
+      definition!.handler = originalHandler;
+    });
+
+    it('should return structured MCP errors when tool execution fails', async () => {
+      mockConfig.getProviderConfig.mockReturnValue({
+        enabled: true,
+        credentials: { apiKey: 'test-key' },
+      });
+
+      server = new CostManagementMCPServer();
+
+      const mockServer = (server as any).server;
+      const callHandler = getRegisteredHandler(mockServer, CallToolRequestSchema);
+      const toolRegistry = (server as any).toolRegistry as Map<string, ToolDefinition>;
+      const definition = toolRegistry.get('provider_list');
+      expect(definition).toBeDefined();
+
+      const originalHandler = definition!.handler;
+      const thrownError = new Error('boom');
+      definition!.handler = jest.fn(() => {
+        throw thrownError;
+      });
+
+      const handleErrorSpy = jest.spyOn(errors, 'handleError');
+      const result = await callHandler({
+        params: {
+          name: 'provider_list',
+          arguments: {},
+        },
+      });
+
+      expect(handleErrorSpy).toHaveBeenCalledWith(thrownError);
+      expect(result.content).toHaveLength(1);
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.success).toBe(false);
+      expect(payload.error).toEqual(
+        expect.objectContaining({
+          code: expect.any(String),
+          message: expect.any(String),
+        }),
+      );
+
+      handleErrorSpy.mockRestore();
+      definition!.handler = originalHandler;
     });
   });
 


### PR DESCRIPTION
## Summary
- add coverage for the MCP ListTools handler to confirm exported metadata is returned
- verify CallTool requests invoke registered tool handlers with the provider registry
- assert tool failures are converted into structured MCP error payloads

## Testing
- npm test -- --runTestsByPath tests/server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6906848b7de08326aec2108ad3be13c3