### PR TITLE
fix(ci): fix schedule workflows (close-stale-dependency-prs / trufflehog)

### DIFF
--- a/.github/workflows/close-stale-dependency-prs.yml
+++ b/.github/workflows/close-stale-dependency-prs.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             const cutoffDays = parseInt(process.env.STALE_DAYS, 10);
             if (Number.isNaN(cutoffDays) || cutoffDays <= 0) {
               core.setFailed(`Invalid STALE_DAYS value: ${process.env.STALE_DAYS}`);

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,68 +5,76 @@ on:
     # Run at 2 AM UTC every Monday
     - cron: '0 2 * * 1'
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   dependency-scan:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v5
-    
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v6
-      with:
-        node-version: 20.x
-        cache: 'npm'
-    
-    - name: Install dependencies
-      run: npm ci
-    
-    - name: Run npm audit
-      run: npm audit --production
-      continue-on-error: true
-    
-    - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/node@master
-      continue-on-error: true
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --production
+        continue-on-error: true
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   secret-scan:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    
-    - name: Detect secrets with Trufflehog
-      uses: trufflesecurity/trufflehog@main
-      with:
-        path: ./
-        base: ${{ github.event.repository.default_branch }}
-        head: HEAD
-        extra_args: --only-verified
-    
-    - name: Check for hardcoded secrets
-      run: |
-        # Check for common patterns
-        patterns=(
-          "sk-[a-zA-Z0-9]{48}"  # OpenAI
-          "AKIA[0-9A-Z]{16}"     # AWS Access Key
-          "-----BEGIN.*KEY-----" # Private keys
-          "token.*[:=].*['\"][a-zA-Z0-9]{20,}" # Generic tokens
-        )
-        
-        for pattern in "${patterns[@]}"; do
-          if git grep -E "$pattern" -- ':(exclude).env*' ':(exclude)*.example' ':(exclude)test*' ':(exclude)*.test.*' ':(exclude)test-*' ':(exclude)*.md'; then
-            echo "WARNING: Potential secret found matching pattern: $pattern"
-            exit 1
-          fi
-        done
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect secrets with Trufflehog (diff scan)
+        if: github.event_name != 'schedule'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified
+
+      - name: Detect secrets with Trufflehog (full scan)
+        if: github.event_name == 'schedule'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          extra_args: --only-verified
+
+      - name: Check for hardcoded secrets
+        run: |
+          # Check for common patterns
+          patterns=(
+            "sk-[a-zA-Z0-9]{48}"  # OpenAI
+            "AKIA[0-9A-Z]{16}"     # AWS Access Key
+            "-----BEGIN.*KEY-----" # Private keys
+            "token.*[:=].*['\"][a-zA-Z0-9]{20,}" # Generic tokens
+          )
+
+          for pattern in "${patterns[@]}"; do
+            if git grep -E "$pattern" -- ':(exclude).env*' ':(exclude)*.example' ':(exclude)test*' ':(exclude)*.test.*' ':(exclude)test-*' ':(exclude)*.md'; then
+              echo "WARNING: Potential secret found matching pattern: $pattern"
+              exit 1
+            fi
+          done
 
   codeql:
     name: CodeQL Analysis
@@ -75,18 +83,18 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-    
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: javascript
-    
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
-    
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- **close-stale-dependency-prs.yml**: Remove duplicate `const core = require('@actions/core')` declaration that caused `SyntaxError: Identifier 'core' has already been declared` — `actions/github-script@v7` already provides `core` in scope
- **security.yml (secret-scan)**: Split TruffleHog into two conditional steps — diff scan for push/PR events (compares base vs HEAD) and full filesystem scan for schedule events (avoids same-commit comparison error)

## Test plan

- [ ] Trigger `Close stale dependency PRs` via workflow_dispatch and verify it succeeds
- [ ] Trigger `Security Scan` via workflow_dispatch or wait for next scheduled run and verify `secret-scan` job passes
- [ ] Verify push/PR triggers still use diff-based TruffleHog scan

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)