### PR TITLE
fix(security): resolve fast-xml-parser audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2497,6 +2497,18 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5290,10 +5302,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.7.tgz",
+      "integrity": "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==",
       "funding": [
         {
           "type": "github",
@@ -5302,7 +5314,25 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7487,6 +7517,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8468,9 +8513,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     "openai": "^6.8.0",
     "zod": "^4.1.12"
   },
+  "overrides": {
+    "fast-xml-parser": "5.7.2"
+  },
   "lint-staged": {
     "*.ts": [
       "eslint --fix"


### PR DESCRIPTION
## 概要

`@aws-sdk/xml-builder` 経由で解決されていた脆弱な `fast-xml-parser` を npm `overrides` で安全版へ固定し、Security Scan の `npm audit --production` 失敗を解消します。AWS SDK 本体の広範な更新は行わず、Node.js >=18 の互換性を維持する最小差分にしています。

Closes #149

## 変更内容

- `package.json` に `fast-xml-parser@5.7.2` の `overrides` を追加
- `package-lock.json` を更新し、production 依存ツリーの `fast-xml-parser` を 5.2.5 から 5.7.2 へ解決
- `@aws-sdk/client-cost-explorer` は 3.922.0 のまま維持し、Issue 対応外の依存一括更新は未実施

## 動作確認 (Verification)

| 項目 | コマンド | 結果 |
| --- | --- | --- |
| Install | `npm ci` | ✅ pass |
| Build | `npm run build` | ✅ pass |
| Lint | `npm run lint` | ✅ 0 errors |
| Format | `npx prettier package.json package-lock.json --check` | ✅ pass |
| Typecheck | `npm run typecheck` | ✅ pass |
| Unit test | `npm test -- --coverage --ci` | ✅ 92 passed |
| Security audit | `npm audit --production` | ✅ found 0 vulnerabilities |
| Dependency tree | `npm ls fast-xml-parser @aws-sdk/client-cost-explorer @aws-sdk/xml-builder --omit=dev` | ✅ `fast-xml-parser@5.7.2 overridden` |
| GitHub Actions | PR checks | ✅ CI / Security Scan all pass |

実行ログ要約: 初回の `npm audit --production` で 16 件の production vulnerability を再現後、`overrides` 追加で 0 件まで解消しました。`npm ci` は exit 0 ですが、ローカル sandbox 制約により Husky が `.git/config` lock warning を 1 行出しています。`npx prettier "src/**/*.ts" --check` は既存の未変更 TypeScript 6 ファイルで warning を出したため、この PR では変更対象の JSON ファイルに限定して format を確認しています。

## 受け入れ条件 (Acceptance Criteria)

- [x] `npm audit --production` exits 0 on main → PR ブランチで同一コマンドが 0 vulnerabilities になることを確認。main 反映後も同じ lockfile が使われます。
- [x] CI Security Scan passes → PR #150 の `dependency-scan` / `secret-scan` / `CodeQL Analysis` が pass。
- [x] No regressions in existing tests → ローカル `npm test -- --coverage --ci` と CI `test (18.x)` / `test (20.x)` が pass。

## スコープ外 (Non-goals)

- Dependabot PR #145 の merge や依存一括更新
- devDependencies 側の audit warning 解消
- 既存 TypeScript ファイルの Prettier 整形

## 影響範囲 / リスク

- 影響API: なし（依存解決のみ）
- 互換性: `@aws-sdk/client-cost-explorer` は現行 3.922.0 のまま維持し、Node.js >=18 前提を変更しません。
- リスク: `overrides` により `fast-xml-parser` のみ上書きするため、将来 AWS SDK を更新した後も override が不要か確認する必要があります。
- ロールバック: この PR の commit を `git revert` すれば元の lockfile 解決へ戻せます。

## レビュー観点 (Review Focus)

- `package.json:L65` — `overrides` で `fast-xml-parser` のみを固定する方針が妥当か。
- `package-lock.json:L5320` — production tree が `fast-xml-parser@5.7.2` に解決され、追加 transitive dependency が想定範囲か。

---

Generated by Codex auto-resolve / Reviewed by knishioka-pm
