### PR TITLE
fix(ci): make TruffleHog scan refs robust

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,13 +43,60 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect secrets with Trufflehog (diff scan)
+      - name: Prepare TruffleHog scan refs
+        id: trufflehog-refs
         if: github.event_name != 'schedule'
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BASE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          null_sha='0000000000000000000000000000000000000000'
+          scan_mode='diff'
+          base=''
+          head=''
+
+          case "$EVENT_NAME" in
+            push)
+              base="$PUSH_BASE"
+              head="$PUSH_HEAD"
+              ;;
+            pull_request)
+              base="$PR_BASE"
+              head="$PR_HEAD"
+              ;;
+            *)
+              scan_mode='full'
+              ;;
+          esac
+
+          if [[ "$scan_mode" == 'diff' ]]; then
+            if [[ -z "$base" || -z "$head" || "$base" == "$head" || "$base" == "$null_sha" || "$head" == "$null_sha" ]]; then
+              echo "Falling back to full TruffleHog scan because diff refs are not comparable for $EVENT_NAME."
+              scan_mode='full'
+              base=''
+              head=''
+            fi
+          fi
+
+          {
+            echo "scan_mode=$scan_mode"
+            echo "base=$base"
+            echo "head=$head"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect secrets with Trufflehog (diff scan)
+        if: github.event_name != 'schedule' && steps.trufflehog-refs.outputs.scan_mode == 'diff'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ steps.trufflehog-refs.outputs.base }}
+          head: ${{ steps.trufflehog-refs.outputs.head }}
           extra_args: --only-verified
 
       - name: Detect secrets with Trufflehog (full scan)
@@ -57,6 +104,17 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
+          base: ''
+          head: HEAD
+          extra_args: --only-verified
+
+      - name: Detect secrets with Trufflehog (fallback full scan)
+        if: github.event_name != 'schedule' && steps.trufflehog-refs.outputs.scan_mode == 'full'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ''
+          head: HEAD
           extra_args: --only-verified
 
       - name: Check for hardcoded secrets


### PR DESCRIPTION
## 概要

Security Scan workflow の TruffleHog diff scan が main push で default branch 名と `HEAD` を比較して同一 commit 扱いになり、`BASE and HEAD commits are the same` で失敗する問題を修正しました。push / pull_request では GitHub event payload の SHA を使って diff scan し、比較不能なケースは full scan に明示的に fallback します。

Closes #151

## 変更内容

- `.github/workflows/security.yml` の `secret-scan` ジョブに TruffleHog 用 base/head 決定ステップを追加
- push は `github.event.before` / `github.sha`、pull_request は PR の base/head SHA を TruffleHog diff scan に渡すよう修正
- base/head が空・同一・null SHA の場合は `base: ''` / `head: HEAD` の fallback full scan に切り替え
- schedule の full scanは維持し、`dependency-scan` と `codeql` は変更なし

## 動作確認 (Verification)

| 項目                | コマンド                                                   | 結果          |
| ------------------- | ---------------------------------------------------------- | ------------- |
| Build               | `npm run build`                                            | ✅ pass       |
| Lint                | `npm run lint`                                             | ✅ 0 errors   |
| Format              | `npx prettier .github/workflows/security.yml --check`      | ✅ pass       |
| Typecheck           | `npm run typecheck`                                        | ✅ pass       |
| Unit test           | `npm test -- --coverage --ci`                              | ✅ 92 passed  |
| Workflow YAML parse | `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/security.yml'); puts 'yaml ok'"` | ✅ pass |
| PR CI               | `gh pr checks 152 --watch --interval 10 --fail-fast`       | ✅ all pass   |

実行ログ要約: 標準チェックは最終差分後にすべて成功。PR CI でも `secret-scan`, `dependency-scan`, `CodeQL Analysis`, `build`, `security`, `test (18.x)`, `test (20.x)` が pass しました。`actionlint` はローカルに未導入だったため追加導入せず、YAML parse と Prettier check で workflow ファイルの機械的確認を実施しました。Jest 実行時に既存の mock error ログは出ますが、15 suites / 92 tests は成功しています。

## 受け入れ条件 (Acceptance Criteria)

- [x] `.github/workflows/security.yml` の TruffleHog diff scan が push / pull_request / schedule でそれぞれ適切な base/head を使う → push は event before/current SHA、pull_request は PR base/head SHA、schedule は full scan を明示
- [x] main への push で `BASE and HEAD commits are the same` が発生しない → base/head が同一または比較不能な場合は diff scan を実行せず fallback full scan に切り替える実装に変更
- [x] schedule 実行は引き続き full scan のまま維持する → schedule 専用 full scan ステップを維持し、`base: ''` / `head: HEAD` を明示
- [x] `dependency-scan` と `codeql` の既存挙動は変えない → 変更範囲は `secret-scan` ジョブ内のみ
- [x] 変更後、少なくともローカルの lint / typecheck / test が通ること → `npm run lint`, `npm run typecheck`, `npm test -- --coverage --ci` が成功
- [ ] push 後の `Security Scan` workflow が green であること → PR の pull_request 経路では `secret-scan` を含む CI が green。main push 後の実 workflow は merge 後に確認が必要

## スコープ外 (Non-goals)

- TruffleHog 以外の secret scan ツール導入
- Snyk / CodeQL / npm audit の設定見直し
- 他 workflow の整理や CI 構成の大規模変更

## 影響範囲 / リスク

- 影響API: なし（GitHub Actions workflow の内部挙動のみ）
- 互換性: アプリケーションコードや公開 API への破壊的変更なし
- ロールバック: この PR のコミットを `git revert` すれば従来の workflow に戻せます
- リスク: PR CI では pull_request 経路を確認済みですが、main push 経路は merge 後の Security Scan で最終確認が必要です

## レビュー観点 (Review Focus)

- `.github/workflows/security.yml:L46` — event 種別ごとの base/head 選択が Issue 要件に合っているか
- `.github/workflows/security.yml:L78` — 空・同一・null SHA の fallback 条件が過不足ないか
- `.github/workflows/security.yml:L102` — schedule と fallback full scan が full scan として明示されているか

---

Generated by Codex auto-resolve / Reviewed by knishioka-pm
