### PR TITLE
chore(ci): add Node 22 compatibility lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     
     steps:
     - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -796,7 +796,8 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 - **CI/CD**: Automated testing on push and PR
 - **Node Support**: Runtime floor is Node.js 18+. CI verifies 18.x, 20.x, and
-  22.x with 20.x as the primary coverage lane.
+  22.x with 20.x as the primary lane for coverage upload and representative
+  build checks.
 - **Coverage**: Comprehensive test suite with coverage reporting
 
 ### Security
@@ -879,6 +880,15 @@ Claudeでの使用例：
 - クレジット期限前のアラート
 
 ### インストール
+
+#### 前提条件
+
+- Node.js 18 以上
+- npm または yarn
+- 監視対象クラウドプロバイダーのアカウント
+
+CI は現在 Node.js 18.x / 20.x / 22.x を検証しており、20.x を
+カバレッジアップロードおよび代表的なビルド検証用の主要レーンとして扱います。
 
 ```bash
 # リポジトリのクローン
@@ -1024,8 +1034,8 @@ npm run typecheck
 ### ビルド＆テスト
 
 - **CI/CD**: プッシュとPR時の自動テスト
-- **Nodeサポート**: runtime floor は Node.js 18+。CI は 18.x / 20.x / 22.x を検証し、
-  20.x を primary coverage lane として扱います
+- **Node サポート**: 動作要件（runtime floor）は Node.js 18+。CI は 18.x / 20.x / 22.x を検証し、
+  20.x を主要なカバレッジアップロードおよびビルド検証用レーン（primary coverage lane）として扱います
 - **カバレッジ**: カバレッジレポート付きの包括的なテストスイート
 
 ### セキュリティ

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ Example usage:
 - npm or yarn
 - Active accounts with the cloud providers you want to monitor
 
+CI currently verifies Node.js 18.x, 20.x, and 22.x. Node.js 20.x is the primary
+lane for coverage upload and representative build checks.
+
 ### Steps
 
 1. Clone the repository:
@@ -792,7 +795,8 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ### Build & Test
 
 - **CI/CD**: Automated testing on push and PR
-- **Node Support**: 18.x and 20.x
+- **Node Support**: Runtime floor is Node.js 18+. CI verifies 18.x, 20.x, and
+  22.x with 20.x as the primary coverage lane.
 - **Coverage**: Comprehensive test suite with coverage reporting
 
 ### Security
@@ -1020,7 +1024,8 @@ npm run typecheck
 ### ビルド＆テスト
 
 - **CI/CD**: プッシュとPR時の自動テスト
-- **Nodeサポート**: 18.xと20.x
+- **Nodeサポート**: runtime floor は Node.js 18+。CI は 18.x / 20.x / 22.x を検証し、
+  20.x を primary coverage lane として扱います
 - **カバレッジ**: カバレッジレポート付きの包括的なテストスイート
 
 ### セキュリティ


### PR DESCRIPTION
## 概要

CI の test matrix に Node.js 22.x を追加し、新しい LTS 世代での互換性を継続確認できるようにしました。runtime floor は `>=18.0.0` のまま維持し、coverage upload は引き続き Node.js 20.x の代表レーンに集約しています。

Closes #153

## 変更内容

- `.github/workflows/ci.yml` の test matrix に `22.x` を追加
- Codecov upload 条件は `matrix.node-version == '20.x'` のまま維持し、primary lane を 20.x に固定
- `README.md` の英語 / 日本語の開発者向け記述に、CI 検証対象 runtime と primary coverage lane を追記
- 自動生成ファイル・lockfile の変更はなし

## 動作確認 (Verification)

| 項目                  | コマンド                                                                                           | 結果                     |
| --------------------- | -------------------------------------------------------------------------------------------------- | ------------------------ |
| Build                 | `npm run build`                                                                                    | ✅ pass                  |
| Lint                  | `npm run lint`                                                                                     | ✅ 0 errors             |
| Format / whitespace   | `git diff --check`                                                                                 | ✅ pass                  |
| Typecheck             | `npm run typecheck`                                                                                | ✅ pass                  |
| Unit test             | `npm test -- --coverage --ci`                                                                      | ✅ 92 passed            |
| Node 22 compatibility | `npx -y -p node@22 -c 'npm run build && npm run lint && npm run typecheck && npm test -- --coverage --ci'` | ✅ all pass / 92 passed |

実行ログ要約: 初回成功。`npm ci` は成功しましたが、既存依存に対する npm audit warning（13 vulnerabilities）が表示されました。テスト中の error log は既存テストの mock error path による出力で、全 test suite は pass しています。

## 受け入れ条件 (Acceptance Criteria)

- [x] CI の test matrix に Node.js `22.x` が追加される → `.github/workflows/ci.yml` の `node-version` matrix に `22.x` を追加
- [x] primary lane は `20.x` のまま維持し、coverage upload などの代表ジョブは 1 レーンに集約される → Codecov 条件を `matrix.node-version == '20.x'` のまま維持
- [x] README または開発者向けドキュメントに、現在の検証対象 runtime（例: 20.x / 22.x）が明記される → `README.md` の英語 / 日本語セクションに CI 検証対象と primary lane を追記
- [x] 既存の build / lint / typecheck / test が Node 22 でも通る → `npx -y -p node@22` で build / lint / typecheck / coverage test を確認
- [x] runtime floor の引き上げ（`engines.node` の変更）は今回必須にしない → `package.json` は未変更

## スコープ外 (Non-goals)

- Node 24 への移行
- `engines.node` の `>=20` への引き上げ
- MCP SDK / OpenAI / TypeScript など依存のアップデート
- release / security workflow の全面的な見直し

## 影響範囲 / リスク

- 影響API: なし（CI と README のみ）
- 互換性: runtime floor は変更していないため、利用者向けの破壊的変更はなし
- リスク: CI test job が 1 レーン増えるため、CI 実行時間は増加する可能性あり
- ロールバック: このコミットを `git revert` すれば matrix と README 記述を元に戻せます

## レビュー観点 (Review Focus)

- `.github/workflows/ci.yml:15` — Node.js 22.x の追加範囲が test matrix に限定されているか
- `.github/workflows/ci.yml:42` — coverage upload が 20.x の代表レーンに維持されているか
- `README.md:216` — runtime floor と CI 検証対象 runtime の区別が読み手に伝わるか

---

Generated by Codex auto-resolve / Reviewed by knishioka-pm
